### PR TITLE
Rename Professional Experience period labels from "Exit" to "Acquired"

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@ background: '/img/bg-alanthealth.jpg'
         <h3 class="exp-group-label">Pioneering Early-Stage Development</h3>
         <div class="exp-list">
           <div class="exp-entry">
-            <div class="exp-period">Exit &middot; 1996</div>
+            <div class="exp-period">Acquired &middot; 1996</div>
             <div class="exp-body">
               <h4 class="exp-title">Surgical Navigation Technologies Inc.</h4>
               <p class="exp-role">Founding Member &amp; Senior Engineer &middot; StealthStation&trade;</p>
@@ -109,7 +109,7 @@ background: '/img/bg-alanthealth.jpg'
             </div>
           </div>
           <div class="exp-entry">
-            <div class="exp-period">Exit &middot; 1999</div>
+            <div class="exp-period">Acquired &middot; 1999</div>
             <div class="exp-body">
               <h4 class="exp-title">IntellX LLC</h4>
               <p class="exp-role">Founding Member &amp; Senior Engineer</p>
@@ -145,7 +145,7 @@ background: '/img/bg-alanthealth.jpg'
         <h3 class="exp-group-label">Corporate Turnarounds</h3>
         <div class="exp-list">
           <div class="exp-entry">
-            <div class="exp-period">Exit &middot; 2007</div>
+            <div class="exp-period">Acquired &middot; 2007</div>
             <div class="exp-body">
               <h4 class="exp-title">Schaerer Swiss Surgical Tables</h4>
               <p class="exp-role">Interim Managing Director</p>
@@ -153,7 +153,7 @@ background: '/img/bg-alanthealth.jpg'
             </div>
           </div>
           <div class="exp-entry">
-            <div class="exp-period">Exit &middot; 2008</div>
+            <div class="exp-period">Acquired &middot; 2008</div>
             <div class="exp-body">
               <h4 class="exp-title">Renishaw Mayfield SA</h4>
               <p class="exp-role">Founding Member &amp; CEO &middot; NeuroMate&reg; robot</p>


### PR DESCRIPTION
"Exit" can be misread as departing a company. "Acquired · YYYY" unambiguously denotes each venture's successful acquisition/buyout and reinforces the homepage's "successful exits" and "public-company acquisitions" stats.

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
